### PR TITLE
Expose the onLoad callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const Iframe = class extends PureComponent {
 			),
 			height: this.props.height || "100%",
 			name: this.props.name || "",
-			width: this.props.width || "100%"
+			width: this.props.width || "100%",
+			onLoad: this.props.onLoad
 		}
 
 		return React.createElement(


### PR DESCRIPTION
Expose the onLoad callback of the React iframe element.

Allows developers to track when the iframe has finished loading the first time or when the iframe's URL has changed.