### PR TITLE
Adding capability to reference the iframe from onLoad prop function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,18 @@ const React = require("react")
 const { PureComponent } = React
 const PropTypes = require("prop-types")
 const objectAssign = require("object-assign")
-function noop() {}
 
 const Iframe = class extends PureComponent {
+	componentDidMount() {
+		this.iframe.onload = () => {
+			if (this.props.onLoad) {
+				this.props.onLoad(this.iframe)
+			}
+		}
+	}
 	render() {
 		const props = {
-			ref: "iframe",
+			ref: f => (this.iframe = f),
 			frameBorder: "0",
 			src: this.props.url,
 			target: "_parent",
@@ -24,8 +30,7 @@ const Iframe = class extends PureComponent {
 			),
 			height: this.props.height || "100%",
 			name: this.props.name || "",
-			width: this.props.width || "100%",
-			onLoad: this.props.onLoad || noop
+			width: this.props.width || "100%"
 		}
 
 		return React.createElement(


### PR DESCRIPTION
This minor change allows the function referenced by the onLoad prop to receive a reference to the iframe easily.

e.g.

```
const afterLoaded = (iframe) => {
	console.log(iframe.contentWindow.location.href);
}

class Demo extends PureComponent {
	render() {
		return (
			<Iframe
				url="http://localhost:8080/same/origin/url#hashValue=found"
				width="450px"
				height="450px"
				id="myId"
				className="myClassname"
				display="initial"
				position="relative"
				onLoad={afterLoaded}
				allowFullScreen
			/>
		)
	}
}
```

This is useful in instances where there are redirects and the final URL that the iframe is redirected to, assuming the URL is the same domain/port/scheme as the parent. The reference to the iframe allows for other iframe manipulations as well, reading the URL was just useful for my specific use case.