### PR TITLE
Fix: Warning: Setting pre-commit script in package.json > scripts will be deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,12 @@
     "ts:all": "yarn ts:cjs && yarn ts:es && yarn ts:typedefs && cp src/types.d.ts .",
     "test": "jest -c ./jest.config.json src/__tests__/*.tsx",
     "lint": "eslint index.js --config .eslintrc.json",
-    "release": "standard-version",
-    "precommit": "lint-staged"
+    "release": "standard-version"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "license": "ISC",
   "jest": {


### PR DESCRIPTION
```
$ git commit -av

Warning: Setting pre-commit script in package.json > scripts will be deprecated
Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
Or run ./node_modules/.bin/husky-upgrade for automatic update

See https://github.com/typicode/husky for usage
```

move husky git hook from 'script' to 'husky' in package.json