### PR TITLE
Fix(#139): Camelcase 'allowFullScreen' doesn't work when 'allow' attribute is set

### DIFF
--- a/src/iframe.tsx
+++ b/src/iframe.tsx
@@ -90,9 +90,8 @@ const Iframe: ComponentType<IIframe> = ({
 	}
 
 	if (allowFullScreen) {
-		if ("allow" in props) {
-			const currentAllow = props.allow.replace("fullscreen", "")
-			props.allow = `fullscreen ${currentAllow.trim()}`.trim()
+		if ("allow" in props && !props.allow.includes("fullscreen")) {
+			props.allow = `fullscreen; ${props.allow.trim()}`;
 		} else {
 			props.allow = "fullscreen"
 		}


### PR DESCRIPTION
As described in the #139, I went ahead and added 2 changes:

1) After checking if `"allow" in props` I also checked to see if `fullscreen` was **not** included in the `props.allow`. If it's **not** then, yes, proceed to concatenating it to the beginning or the `props.allow` string. If it's already existent, it doesn't make sense to complicate things by removing it and re-adding it to the beginning of the string, as this either will leave orphan `;` hanging or with have to make more unnecessary work to clean it up.

2) Removed the `.trim()` from the end of the line as it was redundant. It is already being done when using it inside the string literal.